### PR TITLE
Mis à jour contact.html avec l'Instagram de VahMiré

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -205,7 +205,7 @@
         <h4>Artistes en résidence</h4>
           <ul>
             <li><font color="grey">Kijâtai-Alexandra Veillette-Cheezo</font></li>
-            <li><font color="grey">VahMiré</font> <a href="https://www.vahmire.com/">Site web</a></li>
+            <li><font color="grey">VahMiré</font> <a href="https://www.instagram.com/vahmire2.0/" target='_blank'>Instagram</a></li>
             <li><font color="grey">Craig Commanda</font> <a href="https://www.instagram.com/craigcommandacreations/" target='_blank'>Instagram</a></li>
           </ul>
         </div>


### PR DESCRIPTION
Le lien du site n'est plus bon. Il pointe vers un site de spam. Notifier l'artiste également, car le lien vers le site de spam est également sur son instagram.
En vérifiant avec web archive wayback machine, le site web était correct en 2023 (https://web.archive.org/web/20230206214145/https://www.vahmire.com/).